### PR TITLE
browserify fix

### DIFF
--- a/lib/strtok.js
+++ b/lib/strtok.js
@@ -313,26 +313,27 @@ var parse = function(s, cb) {
                 var bytesCopied = 0;
                 while (bytesCopied < type.len && bufs.length > 0) {
                     var bb = bufs[0];
+                    var copyLength = Math.min(type.len - bytesCopied, bb.length - bufOffset);
 
                     // TODO: Manually copy bytes if we don't need many of them.
                     //       Bouncing down into C++ land to invoke
                     //       Buffer.copy() is expensive enough that we
                     //       shouldnt' do it unless we have a lot of dato to
                     //       copy.
-                    var copied = bb.copy(
+                    bb.copy(
                         b,
                         bytesCopied,
                         bufOffset,
-                        bufOffset + Math.min(type.len - bytesCopied, bb.length - bufOffset)
+                        bufOffset + copyLength
                     );
 
-                    bytesCopied += copied;
+                    bytesCopied += copyLength;
 
-                    if (copied < (bb.length - bufOffset)) {
+                    if (copyLength < (bb.length - bufOffset)) {
                         assert.equal(bytesCopied, type.len);
-                        bufOffset += copied;
+                        bufOffset += copyLength;
                     } else {
-                        assert.equal(bufOffset + copied, bb.length);
+                        assert.equal(bufOffset + copyLength, bb.length);
                         bufs.shift();
                         bufOffset = 0;
                     }


### PR DESCRIPTION
I've started adding browser compatibility to node-musicmetadata and shockingly the only change I had to make to strtok was to count `Buffer.copy()` manually.
